### PR TITLE
Feat: add `StatusNotifierItemProxy::activate` & `StatusNotifierItemProxy::secondary_activate`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "polling 2.8.0",
  "rustix 0.37.27",
  "slab",
- "socket2",
+ "socket2 0.4.10",
  "waker-fn",
 ]
 
@@ -285,6 +285,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cairo-rs"
@@ -1039,6 +1045,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,8 +1588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.5.7",
  "tokio-macros",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1930,6 +1965,7 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 dbusmenu-gtk3 = ["dep:gtk", "dep:dbusmenu-gtk3-sys"]
 
 [dependencies]
-zbus = "3.15.2"
+zbus = { version = "3.15.2", features = ["tokio"] }
 tracing = "0.1.40"
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "time"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,6 +5,7 @@ async fn main() {
     let client = Client::new().await.unwrap();
     let mut tray_rx = client.subscribe();
 
+    #[allow(unused_variables)]
     let initial_items = client.items();
 
     // do something with initial items...

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,10 +5,10 @@ async fn main() {
     let client = Client::new().await.unwrap();
     let mut tray_rx = client.subscribe();
 
-    #[allow(unused_variables)]
     let initial_items = client.items();
 
     // do something with initial items...
+    drop(initial_items);
 
     while let Ok(ev) = tray_rx.recv().await {
         println!("{ev:?}"); // do something with event...

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,15 @@
+use system_tray::client::Client;
+
+#[tokio::main]
+async fn main() {
+    let client = Client::new().await.unwrap();
+    let mut tray_rx = client.subscribe();
+
+    let initial_items = client.items();
+
+    // do something with initial items...
+
+    while let Ok(ev) = tray_rx.recv().await {
+        println!("{ev:?}"); // do something with event...
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -548,7 +548,6 @@ impl Client {
         &self,
         address: String,
         menu_path: String,
-        // ) -> Result<DBusMenuProxy<'_>, zbus::Error> {
     ) -> crate::error::Result<DBusMenuProxy<'_>> {
         let proxy = DBusMenuProxy::builder(&self.connection)
             .destination(address)?


### PR DESCRIPTION
these are typically used when left&middle click on the icon.

for more information, i found this:
https://github.com/Rayzeq/tryfol/blob/bd70ee5c2e699c26003cc0c719ca3c312d4fa219/tryfol-bar/src/backend/status_notifier/proxy/item.rs#L78