### PR TITLE
Make `Client::items` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ categories = ["gui"]
 keywords = ["statusnotifieritem", "dbusmenu", "tokio", "tray"]
 
 [features]
-default = []
+default = ["data"]
+data = []
 dbusmenu-gtk3 = ["dep:gtk", "dep:dbusmenu-gtk3-sys"]
 
 [dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,6 @@ use crate::menu::{MenuDiff, TrayMenu};
 use crate::names;
 use dbus::DBusProps;
 use futures_lite::StreamExt;
-use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::spawn;
 use tokio::sync::broadcast;
@@ -85,6 +84,7 @@ pub struct Client {
     _rx: broadcast::Receiver<Event>,
     connection: Connection,
 
+    #[cfg(feature = "data")]
     items: TrayItemMap,
 }
 
@@ -151,7 +151,6 @@ impl Client {
         watcher_proxy
             .register_status_notifier_host(&wellknown)
             .await?;
-
         let items = TrayItemMap::new();
 
         // handle new items
@@ -243,6 +242,7 @@ impl Client {
             connection,
             tx,
             _rx: rx,
+            #[cfg(feature = "data")]
             items,
         })
     }
@@ -265,7 +265,7 @@ impl Client {
 
         let properties = Self::get_item_properties(destination, &path, &properties_proxy).await?;
 
-        items.new_item(destination.into(), properties.clone());
+        items.new_item(destination.into(), &properties);
 
         tx.send(Event::Add(
             destination.to_string(),
@@ -569,6 +569,7 @@ impl Client {
     }
 
     /// Gets all current items, including their menus if present.
+    #[cfg(feature = "data")]
     #[must_use]
     pub fn items(&self) -> TrayItemMap {
         self.items.clone()

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,59 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tracing::error;
+
+use crate::{item::StatusNotifierItem, menu::TrayMenu};
+
+type BaseMap = HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>;
+
+#[derive(Debug, Clone)]
+pub struct TrayItemMap {
+    inner: Arc<Mutex<BaseMap>>,
+}
+
+impl TrayItemMap {
+    pub fn get_map(&self) -> Arc<Mutex<BaseMap>> {
+        self.inner.clone()
+    }
+
+    pub(super) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+    pub(super) fn new_item(&self, dest: String, item: StatusNotifierItem) {
+        self.inner
+            .lock()
+            .expect("mutex lock should succeed")
+            .insert(dest, (item, None));
+    }
+    pub(super) fn remove_item(&self, dest: &str) {
+        self.inner
+            .lock()
+            .expect("mutex lock should succeed")
+            .remove(dest);
+    }
+    pub(super) fn update_menu(&self, dest: &str, menu: &TrayMenu) {
+        if let Some((_, menu_cache)) = self
+            .inner
+            .lock()
+            .expect("mutex lock should succeed")
+            .get_mut(dest)
+        {
+            menu_cache.replace(menu.clone());
+        } else {
+            error!("could not find item in state");
+        }
+    }
+    pub(super) fn clear_items(&self) -> Vec<String> {
+        let mut items = self.inner.lock().expect("mutex lock should succeed");
+        let keys = items.keys().cloned().collect::<Vec<_>>();
+        for address in keys.iter() {
+            items.remove(address);
+        }
+        keys
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,59 +1,101 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+#[cfg(feature = "data")]
+pub use data_all::TrayItemMap;
 
-use tracing::error;
+#[cfg(not(feature = "data"))]
+pub use data_destination_only::TrayItemMap;
 
-use crate::{item::StatusNotifierItem, menu::TrayMenu};
+#[cfg(feature = "data")]
+mod data_all {
+    use crate::{item::StatusNotifierItem, menu::TrayMenu};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+    use tracing::error;
 
-type BaseMap = HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>;
+    type BaseMap = HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>;
 
-#[derive(Debug, Clone)]
-pub struct TrayItemMap {
-    inner: Arc<Mutex<BaseMap>>,
+    #[derive(Debug, Clone)]
+    pub struct TrayItemMap {
+        inner: Arc<Mutex<BaseMap>>,
+    }
+    impl TrayItemMap {
+        pub fn get_map(&self) -> Arc<Mutex<BaseMap>> {
+            self.inner.clone()
+        }
+
+        pub(crate) fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+        pub(crate) fn new_item(&self, dest: String, item: &StatusNotifierItem) {
+            self.inner
+                .lock()
+                .expect("mutex lock should succeed")
+                .insert(dest, (item.clone(), None));
+        }
+        pub(crate) fn remove_item(&self, dest: &str) {
+            self.inner
+                .lock()
+                .expect("mutex lock should succeed")
+                .remove(dest);
+        }
+        pub(crate) fn update_menu(&self, dest: &str, menu: &TrayMenu) {
+            if let Some((_, menu_cache)) = self
+                .inner
+                .lock()
+                .expect("mutex lock should succeed")
+                .get_mut(dest)
+            {
+                menu_cache.replace(menu.clone());
+            } else {
+                error!("could not find item in state");
+            }
+        }
+        pub(crate) fn clear_items(&self) -> Vec<String> {
+            let mut items = self.inner.lock().expect("mutex lock should succeed");
+            items.drain().map(|(k, _)| k).collect()
+        }
+    }
 }
 
-impl TrayItemMap {
-    pub fn get_map(&self) -> Arc<Mutex<BaseMap>> {
-        self.inner.clone()
-    }
+// #[cfg(not(feature = "data"))]
+mod data_destination_only {
+    use crate::{item::StatusNotifierItem, menu::TrayMenu};
+    use std::{
+        collections::HashSet,
+        sync::{Arc, Mutex},
+    };
 
-    pub(super) fn new() -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
+    #[derive(Debug, Clone)]
+    pub struct TrayItemMap {
+        inner: Arc<Mutex<HashSet<String>>>,
+    }
+    impl TrayItemMap {
+        pub(crate) fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(HashSet::new())),
+            }
         }
-    }
-    pub(super) fn new_item(&self, dest: String, item: StatusNotifierItem) {
-        self.inner
-            .lock()
-            .expect("mutex lock should succeed")
-            .insert(dest, (item, None));
-    }
-    pub(super) fn remove_item(&self, dest: &str) {
-        self.inner
-            .lock()
-            .expect("mutex lock should succeed")
-            .remove(dest);
-    }
-    pub(super) fn update_menu(&self, dest: &str, menu: &TrayMenu) {
-        if let Some((_, menu_cache)) = self
-            .inner
-            .lock()
-            .expect("mutex lock should succeed")
-            .get_mut(dest)
-        {
-            menu_cache.replace(menu.clone());
-        } else {
-            error!("could not find item in state");
+        pub(crate) fn new_item(&self, dest: String, _: &StatusNotifierItem) {
+            self.inner
+                .lock()
+                .expect("mutex lock should succeed")
+                .insert(dest);
         }
-    }
-    pub(super) fn clear_items(&self) -> Vec<String> {
-        let mut items = self.inner.lock().expect("mutex lock should succeed");
-        let keys = items.keys().cloned().collect::<Vec<_>>();
-        for address in keys.iter() {
-            items.remove(address);
+        pub(crate) fn remove_item(&self, dest: &str) {
+            self.inner
+                .lock()
+                .expect("mutex lock should succeed")
+                .remove(dest);
         }
-        keys
+        pub(crate) fn update_menu(&self, _: &str, _: &TrayMenu) {
+            // WE DO NOTHING HERE
+        }
+        pub(crate) fn clear_items(&self) -> Vec<String> {
+            let mut items = self.inner.lock().expect("mutex lock should succeed");
+            items.drain().collect()
+        }
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -60,7 +60,7 @@ mod data_all {
     }
 }
 
-// #[cfg(not(feature = "data"))]
+#[cfg(not(feature = "data"))]
 mod data_destination_only {
     use crate::{item::StatusNotifierItem, menu::TrayMenu};
     use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 /// ```
 mod dbus;
 
+pub mod data;
+
 /// Client for listening to item and menu events,
 /// and associated types.
 pub mod client;


### PR DESCRIPTION
this introduce a feature making items and menus cache optional.
the feature is enable by default.

without the feature, we still preserves the destination of each item, which is for
```
// Handle other watchers unregistering and this one taking over
// It is necessary to clear all items as our watcher will then re-send them all
```
though i haven't seen this gets triggered, maybe it's just me over thinking.