### PR TITLE
fix: NewIcon update event send both icon_name and icon_pixmap

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -146,7 +146,7 @@ impl Debug for IconPixmap {
 }
 
 impl IconPixmap {
-    fn from_array(array: &Array) -> Result<Vec<Self>> {
+    pub fn from_array(array: &Array) -> Result<Vec<Self>> {
         array
             .iter()
             .map(|pixmap| {


### PR DESCRIPTION
we should have both icon_name and icon_pixmap updated when there's a NewIcon update event.

Video shows dingtalk updating icon_pixmap to simulate blink effect:

https://github.com/user-attachments/assets/e7db86fd-db02-438b-ae1b-ea7048b235ed

