### PR TITLE
fix(client): handle invalid icon pixmap

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -473,9 +473,9 @@ impl Client {
                     })
                     .as_deref()
                     .map(Value::downcast_ref::<&Array>)
-                    .transpose()?
+                    .and_then(|res| res.ok())
                     .map(IconPixmap::from_array)
-                    .transpose()?;
+                    .and_then(|res| res.ok());
 
                 Some(Icon {
                     icon_name,


### PR DESCRIPTION
When a `StatusNotifierItem` is updated and the `IconPixmap` property exists but is invalid, the client will log an error and ignore the update. This PR replicates the handling of invalid `IconName` properties for `IconPixmap`, turning the errors into `None`.